### PR TITLE
Syncthing-gtk can't initiated with latest libnotify

### DIFF
--- a/syncthing_gtk/notifications.py
+++ b/syncthing_gtk/notifications.py
@@ -18,7 +18,7 @@ Notifications = None
 try:
 	if not IS_WINDOWS:
 		import gi
-		gi.require_version('Notify', '0.7')
+		gi.require_version('Notify', '0.8')
 		from gi.repository import Notify
 		HAS_DESKTOP_NOTIFY = True
 except ImportError:


### PR DESCRIPTION
After upgrade with libnotify(0.7.12-1 -> 0.8.0-1) yesterday, the syncthing-gtk can't launch.

Find the similiar problem from both
	EndeavorOS forum [link](https://forum.endeavouros.com/t/system-config-printer-error-in-namespace-notify/29251)
	Archlinux bbs [link](https://bbs.archlinux.org/viewtopic.php?id=278077)
change the gi require version from 0.7 -> 0.8 fixed the issue. 
PR Accept お願いします